### PR TITLE
feat: add Platform api override to match react-native(-web)

### DIFF
--- a/src/apis/Platform.js
+++ b/src/apis/Platform.js
@@ -1,0 +1,5 @@
+// @flow
+
+export const OS = process.platform
+
+export const select = (obj: Object) => (process.platform in obj ? obj[process.platform] : obj.default)

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ export {
   NetInfo,
   PanResponder,
   PixelRatio,
-  Platform,
   Share,
   StyleSheet,
   UIManager,
@@ -108,6 +107,7 @@ export {
 export * as Alert from './apis/Alert'
 export * as Clipboard from './apis/Clipboard'
 export * as Linking from './apis/Linking'
+export * as Platform from './apis/Platform'
 
 // components
 export { default as WebView } from './components/WebView'


### PR DESCRIPTION
Great work Paul Le Cam!

Found this gem today and I think it has potential. The folder structure of API's might need to be improved in the future to match react-native-web, but here is a contribution regarding the Platform API.